### PR TITLE
feat: switch login to username and password

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,8 +20,8 @@ window.supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 const translations = {
   en: {
     loginTitle: 'Login',
-    role: 'Role',
-    pin: 'PIN',
+    username: 'Username',
+    password: 'Password',
     submit: 'Submit',
     dashboard: 'Dashboard',
     employees: 'Employees',
@@ -33,6 +33,7 @@ const translations = {
     reports: 'Reports',
     settings: 'Settings',
     logout: 'Logout',
+    invalidCredentials: 'Invalid username or password',
     invalidPin: 'Invalid PIN',
     invalidEmail: 'Invalid email',
     add: 'Add',
@@ -75,8 +76,8 @@ const translations = {
   },
   ar: {
     loginTitle: 'تسجيل الدخول',
-    role: 'الدور',
-    pin: 'الرمز',
+    username: 'اسم المستخدم',
+    password: 'كلمة المرور',
     submit: 'إرسال',
     dashboard: 'لوحة التحكم',
     employees: 'الموظفون',
@@ -88,6 +89,7 @@ const translations = {
     reports: 'التقارير',
     settings: 'الإعدادات',
     logout: 'خروج',
+    invalidCredentials: 'اسم المستخدم أو كلمة المرور غير صحيحة',
     invalidPin: 'رمز غير صحيح',
     invalidEmail: 'بريد غير صالح',
     add: 'إضافة',

--- a/js/login.js
+++ b/js/login.js
@@ -1,14 +1,15 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('loginForm');
-  // ملاحظة: هذا نظام دخول مؤقت.
-  // في تطبيق حقيقي، يجب استخدام نظام المصادقة الخاص بـ Supabase (مثلاً، بالبريد الإلكتروني وكلمة المرور).
-  // تم إزالة نظام PIN لأنه غير متوافق مع قاعدة البيانات.
-  form.addEventListener('submit', e => {
+  form.addEventListener('submit', async e => {
     e.preventDefault();
-    const role = document.getElementById('role').value;
-    // في هذا العرض التوضيحي، نقوم فقط بتعيين دور الجلسة والمتابعة.
-    setSession(role);
-    addAudit('login', role, `Logged in as ${role}`);
+    const username = document.getElementById('username').value.trim();
+    const password = document.getElementById('password').value;
+    const { error } = await supabase.auth.signInWithPassword({ email: username, password });
+    if (error) {
+      alert(t('invalidCredentials'));
+      return;
+    }
+    addAudit('login', 'user', username);
     window.location.href = 'index.html';
   });
 });

--- a/login.html
+++ b/login.html
@@ -16,15 +16,12 @@
     <h1 class="text-2xl mb-4" data-i18n="loginTitle"></h1>
     <form id="loginForm" class="space-y-4">
       <div>
-        <label class="block" for="role" data-i18n="role"></label>
-        <select id="role" class="border p-2 w-full">
-          <option value="Admin">Admin</option>
-          <option value="Viewer">Viewer</option>
-        </select>
+        <label class="block" for="username" data-i18n="username"></label>
+        <input type="text" id="username" class="border p-2 w-full" />
       </div>
       <div>
-        <label class="block" for="pin" data-i18n="pin"></label>
-        <input type="password" id="pin" maxlength="4" class="border p-2 w-full" />
+        <label class="block" for="password" data-i18n="password"></label>
+        <input type="password" id="password" class="border p-2 w-full" />
       </div>
       <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded" data-i18n="submit"></button>
     </form>


### PR DESCRIPTION
## Summary
- replace role/PIN login form with username and password fields
- authenticate via Supabase email/password instead of role selection
- add translation strings for username, password and invalid credentials

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc5f548eb0832e8522120cf447704b