### PR TITLE
Fix lint errors and improve type safety

### DIFF
--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -4,6 +4,13 @@ import jwt from 'jsonwebtoken';
 import { setCookie } from 'nookies';
 import pool from '@/lib/db';
 
+interface User {
+  id: number;
+  username: string;
+  password: string;
+  role: string | null;
+}
+
 // It is recommended to use environment variables for the JWT secret.
 // Create a .env.local file in the root of your project and add the following:
 // JWT_SECRET=your-super-secret-key
@@ -25,7 +32,7 @@ export default async function handler(
   }
 
   try {
-    const { rows }: any = await pool.query(
+    const { rows } = await pool.query<User>(
       'SELECT id, username, password, role FROM users WHERE username = $1',
       [username]
     );

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -2,6 +2,10 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import bcrypt from 'bcryptjs';
 import pool from '@/lib/db';
 
+interface ExistingUser {
+  id: number;
+}
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -17,7 +21,7 @@ export default async function handler(
   }
 
   try {
-    const { rows }: any = await pool.query(
+    const { rows } = await pool.query<ExistingUser>(
       'SELECT id FROM users WHERE username = $1',
       [username]
     );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { parseCookies } from 'nookies';
+import type { GetServerSidePropsContext } from 'next';
 
 export default function Dashboard() {
   const router = useRouter();
@@ -48,9 +49,9 @@ export default function Dashboard() {
         <div className="bg-white p-4 rounded shadow mb-4">
           <h2 className="text-xl mb-2">Latest Audit</h2>
           <ul className="list-disc pl-5">
-            <li>User 'admin' logged in.</li>
-            <li>User 'admin' added a new employee.</li>
-            <li>User 'admin' updated payroll for employee #123.</li>
+            <li>User &apos;admin&apos; logged in.</li>
+            <li>User &apos;admin&apos; added a new employee.</li>
+            <li>User &apos;admin&apos; updated payroll for employee #123.</li>
           </ul>
         </div>
         <div className="bg-white p-4 rounded shadow">
@@ -66,7 +67,7 @@ export default function Dashboard() {
   );
 }
 
-export async function getServerSideProps(ctx: any) {
+export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { token } = parseCookies(ctx);
 
   if (!token) {

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -27,7 +27,8 @@ export default function LoginPage() {
         const message = await response.text();
         setError(message);
       }
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('An unexpected error occurred.');
     }
   };

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -39,7 +39,8 @@ export default function SignupPage() {
       } else {
         setError(data);
       }
-    } catch (error) {
+    } catch (err) {
+      console.error(err);
       setError('An unexpected error occurred.');
     }
   };


### PR DESCRIPTION
## Summary
- escape apostrophes in dashboard audit log
- type `getServerSideProps` context and database query results
- log caught errors in login and signup pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcaa6c8be0832e85df9f96b3337650