### PR TITLE
fix: validate JWT secret

### DIFF
--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -9,10 +9,17 @@ import type { Database } from '@/lib/supabase/types';
 // Create a .env.local file in the root of your project and set:
 // JWT_SECRET=your-super-secret-key
 
-const JWT_SECRET = process.env.JWT_SECRET;
-if (!JWT_SECRET) {
-  throw new Error('JWT_SECRET environment variable is not set');
-}
+// Safely read the JWT secret from the environment. Wrapping this in an
+// IIFE allows TypeScript to infer the returned value is always a string
+// after the runtime check, avoiding `string | undefined` issues at the
+// call site when signing the token.
+const JWT_SECRET: string = (() => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not set');
+  }
+  return secret;
+})();
 
 export default async function handler(
   req: NextApiRequest,

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import bcrypt from 'bcryptjs';
 import supabase from '@/lib/db';
+import type { Database } from '@/lib/supabase/types';
 
 export default async function handler(
   req: NextApiRequest,
@@ -43,9 +44,15 @@ export default async function handler(
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
+    const newUser: Database['public']['Tables']['users']['Insert'] = {
+      username,
+      password: hashedPassword,
+      role: 'user',
+    };
+
     const { error: insertError } = await supabase
       .from('users')
-      .insert([{ username, password: hashedPassword, role: 'user' }]);
+      .insert([newUser]);
 
     if (insertError) {
       throw insertError;


### PR DESCRIPTION
## Summary
- ensure JWT secret is retrieved safely and typed for jwt.sign
- type the Supabase signup insertion with the generated Database schema

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc'; `npm install` failed with 403)*
- `npm run build` *(fails: next command not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bd694af128832eb0fbeb956c7eaa54